### PR TITLE
Software Upgrade v29

### DIFF
--- a/proposals/052-dkim-pubkey-burnt-com.json
+++ b/proposals/052-dkim-pubkey-burnt-com.json
@@ -1,0 +1,22 @@
+{
+  "messages": [
+    {
+      "@type": "/xion.dkim.v1.MsgAddDkimPubKeys",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "dkim_pubkeys": [
+        {
+          "domain": "burnt.com",
+          "pub_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDl/NganeSWTkvH+myXHF1xw10h9do+CniB5C8ppjLViGTfT9fH487djdKKXP1DcOHYq/Q4uDNySr9ObqkiFRwALv+CemPbS7MAoFTLAL1YvqP/qCdR6n/kg3s10AwLObbokyTwb7e31z0fDSNRMs9aovA9gI80LRSf7Y/k8XKoRwIDAQAB",
+          "poseidon_hash": "Kta+yFzylsw9OK1YPjUerY047cDedB7H9gg3IlTEfRc=",
+          "selector": "google",
+          "version": "VERSION_DKIM1_UNSPECIFIED",
+          "key_type": "KEY_TYPE_RSA_UNSPECIFIED"
+        }
+      ]
+    }
+  ],
+  "title": "Add DKIM Public Key for burnt.com",
+  "summary": "This proposal adds the DKIM public key record for burnt.com to enable email-based authentication for burnt.com email addresses in the DKIM module.",
+  "deposit": "5000000000uxion",
+  "expedited": true
+}

--- a/proposals/057-upgrade-v28.json
+++ b/proposals/057-upgrade-v28.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "plan": {
+        "name": "v28",
+        "height": "12823000",
+        "info": "https://raw.githubusercontent.com/burnt-labs/xion-testnet-2/main/releases/v28.json",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "title": "Software Upgrade v28 - Security Enhancement",
+  "summary": "Software Upgrade v28 - Security Enhancement.",
+  "deposit": "1000000000uxion",
+  "expedited": false
+}

--- a/proposals/058-upgrade-v29.json
+++ b/proposals/058-upgrade-v29.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "plan": {
+        "name": "v29",
+        "height": "14235000",
+        "info": "https://raw.githubusercontent.com/burnt-labs/xion-testnet-2/main/releases/v29.json",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "title": "Software Upgrade v29",
+  "summary": "Software Upgrade v29.",
+  "deposit": "1000000000uxion",
+  "expedited": false
+}

--- a/proposals/058-upgrade-v29.json
+++ b/proposals/058-upgrade-v29.json
@@ -12,7 +12,7 @@
     }
   ],
   "title": "Software Upgrade v29",
-  "summary": "Software Upgrade v29.",
+  "summary": "Software Upgrade v29",
   "deposit": "1000000000uxion",
   "expedited": false
 }

--- a/releases/v29.json
+++ b/releases/v29.json
@@ -1,0 +1,8 @@
+{
+  "binaries": {
+    "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_linux_amd64.tar.gz?checksum=sha256:63f2a48d8664acb3db1d12a11780da36537575c4e8678fb2e0ab6c0a64dfa4af",
+    "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_linux_arm64.tar.gz?checksum=sha256:76cfb7f8356e0feb111d3b4feeaef7cdf10ff95cc9b7a28329660a3a92051e41",
+    "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_darwin_amd64.tar.gz?checksum=sha256:52fb0e7bb4c65a2170b8eb2ae94d9489251014ab33379569437802b15b5dc6ff",
+    "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_darwin_arm64.tar.gz?checksum=sha256:6865a82aa1b8a7b4245fbe4d98e227d6561d9c372472f4d9b09dcadd20c25948"
+  }
+}


### PR DESCRIPTION
## Summary
- Add upgrade proposal `058-upgrade-v29.json` (height 14235000, proposal 58, non-expedited)
- Add release binaries `releases/v29.json` with SHA256 checksums for v29.0.0-rc1

## Details
- **Version**: v29.0.0-rc1
- **Upgrade height**: 14,235,000
- **Proposal**: 58
- **Deposit**: 1,000,000,000 uxion
- **Expedited**: false

🤖 Generated with [Claude Code](https://claude.com/claude-code)